### PR TITLE
Update python test folder names

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ pip install git+https://github.com/google-research/perch-hoplite.git
 
 Then run the tests and check that they pass:
 ```bash
-python -m unittest discover -s hoplite/db/tests -p "*test.py"
-python -m unittest discover -s hoplite/taxonomy -p "*test.py"
-python -m unittest discover -s hoplite/zoo -p "*test.py"
-python -m unittest discover -s hoplite/agile/tests -p "*test.py"
+python -m unittest discover -s perch_hoplite/db/tests -p "*test.py"
+python -m unittest discover -s perch_hoplite/taxonomy -p "*test.py"
+python -m unittest discover -s perch_hoplite/zoo -p "*test.py"
+python -m unittest discover -s perch_hoplite/agile/tests -p "*test.py"
 ```
 
 Or, install with poetry:


### PR DESCRIPTION
This PR corrects a small typo in the setup instructions of the README. The original version may confuse new users installing dependencies because the folder containing tests was previously hoplite and now is perch_hoplite.