### PR TITLE
added version to [project] in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = "Apache 2.0"
 # Project metadata. Available keys are documented at:
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata
 name = "perch-hoplite"
+version = "0.1.1"
 description = "Tooling for agile modeling on large machine perception embedding databases."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Added the `version` to the `[project]`.
Some tools like [`uv`](https://docs.astral.sh/uv/) require the version to be present under `[project]` if I try to install from git.
(version 0.1.1 is not yet available on pypi, but I'm trying to resolve some dependency issues currently)