### PR TITLE
URL Mapping to Dictionary

### DIFF
--- a/perch_hoplite/zoo/hub.py
+++ b/perch_hoplite/zoo/hub.py
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#       http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,43 +46,49 @@ YAMNET_SLUG = 'google/yamnet'
 VGGISH_SLUG = 'google/vggish'
 
 
-def normalize_slug(model_slug: str, model_version: int | None = None) -> str:
-  """Convert the old full URLs used by TensorflowHub to KaggleHub slugs."""
-  if model_slug == PERCH_TF_HUB_URL:
-    return PERCH_V1_SLUG
-  elif model_slug == PERCH_V2_TF_HUB_URL:
-    return PERCH_V2_SLUG
-  elif model_slug == SURFPERCH_TF_HUB_URL:
-    return SURFPERCH_SLUG
-  elif model_slug.startswith(BASE_KAGGLE_URL):
-    return model_slug[len(BASE_KAGGLE_URL) :]
+# Dictionary mapping old TFHub-style URLs to new KaggleHub slugs.
+OLD_URL_TO_SLUG_MAP = {
+    PERCH_TF_HUB_URL: PERCH_V1_SLUG,
+    PERCH_V2_TF_HUB_URL: PERCH_V2_SLUG,
+    SURFPERCH_TF_HUB_URL: SURFPERCH_SLUG,
+}
 
-  if model_slug == PERCH_V1_SLUG and model_version in (5, 6, 7):
-    # Due to SNAFUs uploading the new model version to KaggleModels,
-    # some version numbers were skipped.
-    raise ValueError('TFHub version 5, 6, and 7 do not exist.')
-  if model_version is not None:
-    return f'{model_slug}/{model_version}'
-  return model_slug
+
+def normalize_slug(model_slug: str, model_version: int | None = None) -> str:
+    """Convert the old full URLs used by TensorflowHub to KaggleHub slugs."""
+    # Check for direct URL mapping first.
+    if model_slug in OLD_URL_TO_SLUG_MAP:
+        return OLD_URL_TO_SLUG_MAP[model_slug]
+
+    # Handle case where a full, modern Kaggle Models URL is passed.
+    elif model_slug.startswith(BASE_KAGGLE_URL):
+        return model_slug[len(BASE_KAGGLE_URL) :]
+
+    if model_slug == PERCH_V1_SLUG and model_version in (5, 6, 7):
+        # Due to SNAFUs uploading the new model version to KaggleModels,
+        # some version numbers were skipped.
+        raise ValueError('TFHub version 5, 6, and 7 do not exist.')
+    if model_version is not None:
+        return f'{model_slug}/{model_version}'
+    return model_slug
 
 
 def load(model_slug: str, model_version: int | None = None):
-  """Download and load a model from KaggleHub."""
-  if model_slug.startswith('/tmp'):
-    # Assume this is a path to a downloaded model, rather than a kaggle model.
-    return tf.saved_model.load(model_slug)
+    """Download and load a model from KaggleHub."""
+    if model_slug.startswith('/tmp'):
+        return tf.saved_model.load(model_slug)
 
-  model_path = normalize_slug(model_slug, model_version)
-  cached_model_path = kagglehub.model_download(model_path)
-  model = tf.saved_model.load(cached_model_path)
-  return model
+    model_path = normalize_slug(model_slug, model_version)
+    cached_model_path = kagglehub.model_download(model_path)
+    model = tf.saved_model.load(cached_model_path)
+    return model
 
 
 def resolve(model_slug: str, model_version: int | None = None) -> str:
-  """Download a model from KaggleHub and return the cached model's path."""
-  if model_slug.startswith('/tmp'):
-    # Assume this is a path to a downloaded model, rather than a kaggle model.
-    return model_slug
-  model_path = normalize_slug(model_slug, model_version)
-  cached_model_path = kagglehub.model_download(model_path)
-  return cached_model_path
+    """Download a model from KaggleHub and return the cached model's path."""
+    if model_slug.startswith('/tmp'):
+        # Assume this is a path to a downloaded model, rather than a kaggle model.
+        return model_slug
+    model_path = normalize_slug(model_slug, model_version)
+    cached_model_path = kagglehub.model_download(model_path)
+    return cached_model_path


### PR DESCRIPTION
I introduced a new global dictionary, **`OLD_URL_TO_SLUG_MAP`**, to store the explicit mapping between the long, deprecated **TensorFlow Hub URLs** and their new, shorter **Kaggle Hub slugs**.

The **`normalize_slug`** function was then updated to use a single **dictionary lookup** ins ead of multiple `if/elif` statements. This architectural change directly improves **readability** and **maintainability**, making it easier and  cleaner to add or update legacy URL mappings in the future.