### PR TITLE
Fix pip optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,38 +20,32 @@ authors = [
     {name = "Bart van Merriënboer", email="bartvm@google.com"},
     {name = "Frank Zhang", email="zhangfrank@google.com"},
 ]
-dependencies = [
-    "absl-py (>=1.4.0,<1.5.0)",
-    "etils[epath] (>=1.5.0,<1.6.0)",
-    "imageio (>=2.5.0,<2.6.0)",
-    "ipywidgets (>=8.1,<9)",
-    "jax[flax] (>=0.4.16,<0.5)",
-    "librosa (>=0.10.1,<0.11.0)",
-    "matplotlib (>=3.6.1,<3.7.0)",
-    "ml-collections (>=1.0.0,<2.0.0)",
-    "notebook (>=7.0.4,<7.1.0)",
-    "numpy (>=1.24.0)",
-    "pandas[gcp] (>=2.1.1,<3.0.0)",
-    "usearch (>=2.16,<2.18)",
-]
 
-[project.optional-dependencies]
-tf = ["tensorflow>=2.16,<2.17", "tensorflow-hub>=0.16,<0.17"]
-jax = ["flax>=0.8.1,<0.9", "jax>=0.4.16,<0.5"]
+[tool.poetry.dependencies]
+# These dependencies are part of the implicit 'main' group, meaning
+# they will be installed when using `pip install`.
+python = ">=3.10"
+absl-py = ">=1.4.0,<1.5.0"
+etils = {extras = ["epath"], version = ">=1.5.0,<1.6.0"}
+imageio = ">=2.5.0,<2.6.0"
+ipywidgets = ">=8.1,<9"
+librosa = ">=0.10.1,<0.11.0"
+matplotlib = ">=3.6.1,<3.7.0"
+ml-collections = ">=1.0.0,<2.0.0"
+notebook = ">=7.0.4,<7.1.0"
+numpy = ">=1.24.0"
+pandas = {extras = ["gcp"], version = ">=2.1.1,<3.0.0"}
+usearch = ">=2.16,<2.18"
 
-[tool.poetry.group.tf]
-optional = false
+# Optional dependencies for extras
+tensorflow = {version = "^2.16", optional = true}
+tensorflow-hub = {version = "^0.16.0", optional = true}
+flax = {version = "^0.8.1", optional = true}
+jax = {version = "^0.4.16", optional = true}
 
-[tool.poetry.group.tf.dependencies]
-tensorflow = "^2.16"
-tensorflow-hub = "^0.16.0"
-
-[tool.poetry.group.jax]
-optional = true
-
-[tool.poetry.group.jax.dependencies]
-flax = "^0.8.1"
-jax = "^0.4.16"
+[tool.poetry.extras]
+tf = ["tensorflow", "tensorflow-hub"]
+jax = ["flax", "jax"]
 
 [build-system]
 requires = ["poetry-core>=1.5.0"]


### PR DESCRIPTION
This PR is to fixup #20 which previously was incomplete. The author had noted
> The optional dependency seems to work fine with a local copy, but the expected syntax with installing from github seems not to find the tf optional dependency

I believe this PR fixes that now.

(although the branch being targeted is still based on a fairly old revision, so there will be some merge conflicts to follow-up on before it gets into `main`)